### PR TITLE
Update some Name ERROR 修复了一下文件命名错误

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -393,7 +393,19 @@ def down_zj(it):
         an[a[i].text] = a[i].xpath('@href')[0].split('/')[-1]
     if ele.xpath('//h1/text()')==[]:
         return ['err',0,0]
-    return [ele.xpath('//h1/text()')[0],an,ele.xpath('//span[@class="info-label-yellow"]/text()')]
+    # 提取标题
+    title_list = ele.xpath('//h1/text()')
+    if not title_list:
+        return ['err', 0, 0]
+
+    # 获取第一个标题
+    title = title_list[0]
+
+    # 删除标题中的冒号
+    clean_title = title.replace(':', '')
+
+    return [clean_title, an, ele.xpath('//span[@class="info-label-yellow"]/text()')]
+
 
 def interpreter(uni):
     global CODE_ST,charset


### PR DESCRIPTION
在一些特殊情况，小说的名字出现的是":"而不是“：”,这种情况下txt文件将不能正常生成，写入（在Windows中，":"是非法字符）。所以我把":"给删除，这样子就可以解决这个问题。如果您有注意到，并且有更好的解决方案，可以去解决它，我的解决方案十分简易并且是未考虑多种情况的哈哈哈。