### PR TITLE
fix: replace requests with curl_cffi to bypass fanqienovel anti-scraping

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ Flask-SocketIO
 gevent
 gevent-websocket
 beautifulsoup4
+curl_cffi
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from curl_cffi import requests as req #
+from curl_cffi import requests as req #fuck copilot 
 from lxml import etree
 from ebooklib import epub
 from tqdm import tqdm
@@ -943,8 +943,8 @@ class NovelDownloader:
                 try:
                     response = req.get(
                         f'https://fanqienovel.com/api/reader/full?itemId={chapter_id}',
-                        headers=headers
-                        ,impersonate="chrome"
+                        headers=headers,
+                        impersonate="chrome"#fuck copilot
                     )
                     content = json.loads(response.text)['data']['chapterData']['content']
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import requests as req
+from curl_cffi import requests as req #
 from lxml import etree
 from ebooklib import epub
 from tqdm import tqdm
@@ -213,7 +213,7 @@ class NovelDownloader:
         }
 
         try:
-            response = req.get(url, params=params, headers=self.headers)
+            response = req.get(url, params=params, headers=self.headers,impersonate="chrome")
             response.raise_for_status()
             data = response.json()
 
@@ -870,7 +870,7 @@ class NovelDownloader:
     def _get_chapter_list(self, novel_id: int) -> tuple:
         """Get novel info and chapter list"""
         url = f'https://fanqienovel.com/page/{novel_id}'
-        response = req.get(url, headers=self.headers)
+        response = req.get(url, headers=self.headers,impersonate="chrome")
         ele = etree.HTML(response.text)
 
         chapters = {}
@@ -903,7 +903,7 @@ class NovelDownloader:
                 response = req.get(
                     f'https://fanqienovel.com/reader/{chapter_id}',
                     headers=headers,
-                    timeout=10
+                    timeout=10,impersonate="chrome"
                 )
                 response.raise_for_status()
 
@@ -944,6 +944,7 @@ class NovelDownloader:
                     response = req.get(
                         f'https://fanqienovel.com/api/reader/full?itemId={chapter_id}',
                         headers=headers
+                        ,impersonate="chrome"
                     )
                     content = json.loads(response.text)['data']['chapterData']['content']
 
@@ -962,7 +963,7 @@ class NovelDownloader:
         """Get author information from novel page"""
         url = f'https://fanqienovel.com/page/{novel_id}'
         try:
-            response = req.get(url, headers=self.headers)
+            response = req.get(url, headers=self.headers,impersonate="chrome")
             soup = BeautifulSoup(response.text, 'html.parser')
             script_tag = soup.find('script', type="application/ld+json")
             if script_tag:
@@ -977,7 +978,7 @@ class NovelDownloader:
         """Get cover image URL from novel page"""
         url = f'https://fanqienovel.com/page/{novel_id}'
         try:
-            response = req.get(url, headers=self.headers)
+            response = req.get(url, headers=self.headers,impersonate="chrome")
             soup = BeautifulSoup(response.text, 'html.parser')
             script_tag = soup.find('script', type="application/ld+json")
             if script_tag:
@@ -991,7 +992,7 @@ class NovelDownloader:
     def _add_cover_to_epub(self, book: epub.EpubBook, cover_url: str):
         """Add cover image to EPUB book"""
         try:
-            response = req.get(cover_url)
+            response = req.get(cover_url,impersonate="chrome")
             if response.status_code == 200:
                 book.set_cover('cover.jpg', response.content)
 

--- a/src/ref_main.py
+++ b/src/ref_main.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import requests as req
+from curl_cffi import requests as req
 from lxml import etree
 from lxml import html
 from tkinter import Tk, filedialog
@@ -223,7 +223,7 @@ def down_zj(it):
     an = {}
     headers = {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.63 Safari/537.36'}
-    response = req.get('https://fanqienovel.com/page/' + str(it), headers=headers)
+    response = req.get('https://fanqienovel.com/page/' + str(it), headers=headers,impersonate="chrome")
     if response.status_code == 200:
         time.sleep(1)
         ele = etree.HTML(response.text)
@@ -354,7 +354,7 @@ def down_book(it, chapter_range=""):
         json.dump(zj, json_file, ensure_ascii=False)
 
     url = f'https://fanqienovel.com/page/{it}'
-    response = req.get(url)
+    response = req.get(url,impersonate="chrome")
     soup = BeautifulSoup(response.text, 'html.parser')
     name_element = soup.find('h1')
     if name_element:
@@ -434,7 +434,7 @@ def down_book_epub(it, chapter_range=""):
     book_json_path = os.path.join(bookstore_dir, safe_name + '.json')
 
     url = f'https://fanqienovel.com/page/{it}'
-    response = req.get(url)
+    response = req.get(url,impersonate="chrome")
     soup = BeautifulSoup(response.text, 'html.parser')
     author_name_element = soup.find('div', class_='author-name')
     author_name = None
@@ -535,7 +535,7 @@ def down_book_html(it, chapter_range=""):
             existing_json_content = json.load(json_file)
 
     url = f'https://fanqienovel.com/page/{it}'
-    response = req.get(url)
+    response = req.get(url,impersonate="chrome")
     soup = BeautifulSoup(response.text, 'html.parser')
     name_element = soup.find('h1')
     if name_element:
@@ -958,7 +958,7 @@ def down_book_latex(it, chapter_range=""):
 
     # 获取作者信息和内容简介
     url = f'https://fanqienovel.com/page/{it}'
-    response = req.get(url)
+    response = req.get(url,impersonate="chrome")
     soup = BeautifulSoup(response.text, 'html.parser')
     # 获取小说名
     name_element = soup.find('h1')
@@ -1028,7 +1028,7 @@ def search():
         if key == '':
             return 'b'
         url = f"https://api5-normal-lf.fqnovel.com/reading/bookapi/search/page/v/?query={key}&aid=1967&channel=0&os_version=0&device_type=0&device_platform=0&iid=466614321180296&passback={{(page-1)*10}}&version_code=999"
-        response = req.get(url)
+        response = req.get(url,impersonate="chrome")
         if response.status_code == 200:
             data = response.json()
             if data['code'] == 0:
@@ -1202,7 +1202,7 @@ class Config:
             # 检查必要功能是否可用
             try:
                 # 测试请求功能
-                req.get('https://www.baidu.com', timeout=1)
+                req.get('https://www.baidu.com', timeout=1,impersonate="chrome")
                 check_results['runtime_env']['details'].append("✓ 网络请求功能正常")
             except:
                 pass
@@ -1811,7 +1811,7 @@ def export_audiobook(book_id, chapter_range=""):
         def get_audio_url(chapter_id):
             try:
                 api_url = f"https://reading.snssdk.com/reading/reader/audio/playinfo/?tone_id=1&item_ids={chapter_id}&pv_player=-1&aid=1967"
-                response = req.get(api_url, headers=headers)
+                response = req.get(api_url, headers=headers,impersonate="chrome")
                 if response.status_code == 200:
                     data = response.json()
                     if data.get("code") == 0 and data.get("data"):
@@ -1831,7 +1831,7 @@ def export_audiobook(book_id, chapter_range=""):
                     return False
                     
                 output_path = os.path.join(audio_dir, f"{sanitize_filename(chapter_title)}.mp3")
-                response = req.get(audio_url, stream=True)
+                response = req.get(audio_url, stream=True,impersonate="chrome")
                 response.raise_for_status()
                 
                 with open(output_path, 'wb') as f:
@@ -2185,7 +2185,7 @@ while True:
                     continue
                 author_name = None
                 url = f'https://fanqienovel.com/page/{book_id}'
-                response = req.get(url)
+                response = req.get(url,impersonate="chrome")
                 soup = BeautifulSoup(response.text, 'html.parser')
                 script_tag = soup.find('script', type="application/ld+json")
                 if script_tag:

--- a/src/ref_main.py
+++ b/src/ref_main.py
@@ -23,9 +23,7 @@ from io import BytesIO
 class NetworkManager:
     def __init__(self):
         self.session = req.Session()
-        self.session.mount('http://', req.adapters.HTTPAdapter(max_retries=3))
-        self.session.mount('https://', req.adapters.HTTPAdapter(max_retries=3))
-        
+        #fuck github fuck microsoft fuck copilot        
         self.session.headers.update({
             'User-Agent': random.choice(headers_lib)['User-Agent'],
             'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
@@ -50,6 +48,7 @@ class NetworkManager:
                     method,
                     url,
                     timeout=timeout,
+                    impersonate="chrome",
                     **kwargs
                 )
                 response.raise_for_status()

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,5 +1,4 @@
 tqdm
-requests
 urllib3
 lxml
 ebooklib

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -8,4 +8,5 @@ Flask-SocketIO
 gevent
 gevent-websocket
 beautifulsoup4
+curl_cffi
 


### PR DESCRIPTION
使用 curl_cffi 库替换原有 requests 库并伪装 TLS 指纹以规避番茄小说的反爬机制
西红柿最近给阅读器加了反爬，requests会被人机验证拦，修了一下，用curl_cffi给原来的requests替换了，伪装TLS指纹为chrome浏览器
In request-based HTTP clients, the standard TLS handshake fingerprint is easily identified by CDN services like fanqienovel.com, causing connection failures. This commit replaces the requests library with curl_cffi, which supports TLS fingerprint impersonation, and adds the impersonate=chrome parameter to all HTTP requests to mimic a real browser TLS handshake.
