### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Before using this program, please ensure compliance with relevant laws and regul
 
 ## Star趋势
 
-![Stars](https://api.star-history.com/svg?repos=ying-ck/fanqienovel-downloader&type=Date)
+![Stars](https://star-history.dera.page/svg?repos=ying-ck/fanqienovel-downloader&type=Date)
 
 ## 赞助
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub's stargazer API restrictions. This change updates the chart URL to a working source so the chart renders correctly again.